### PR TITLE
Upgrade to v2025.04.02

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "DumbBudget"
 description.en = "stupid simple budget app"
 description.fr = "application de budget simple"
 
-version = "2025.03.26~ynh1"
+version = "2025.04.02~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -57,8 +57,8 @@ ram.runtime = "70M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/DumbWareio/DumbBudget/archive/f7eb792ee69a40844075393b79da7300c5836c06.tar.gz"
-    sha256 = "7984a0010e4c432cf6cf702cac3f314d789621021b5319383daf88ab7b850f9c"
+    url = "https://github.com/DumbWareio/DumbBudget/archive/f2191167464ab4cce0ef47663180f7af8769f8d2.tar.gz"
+    sha256 = "997881c13bd093eb93c71ecd62083cb06ccc562be886b9ac0331ae6f818386d1"
     autoupdate.upstream = "https://github.com/DumbWareio/DumbBudget"
     autoupdate.strategy = "latest_github_commit"
 


### PR DESCRIPTION
Upgrade sources
- `main` v2025.04.02: https://github.com/DumbWareio/DumbBudget/compare/f7eb792ee69a40844075393b79da7300c5836c06...f2191167464ab4cce0ef47663180f7af8769f8d2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
